### PR TITLE
Fix: drop duplicate tag cells from previous format migrations

### DIFF
--- a/notebooks/cesm_bias.ipynb
+++ b/notebooks/cesm_bias.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "86fe2dcf",
+   "id": "412d50e6",
    "metadata": {},
    "source": [
     "---\n",
@@ -22,18 +22,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0a7ec0d",
+   "id": "3a4619b6",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-object-store\"><span class=\"tag tag-origin\">origin:ncar-object-store</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-bias-correction\"><span class=\"tag tag-task\">task:bias-correction</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "17e716b5",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-bias-correction\"><span class=\"tag tag-task\">task:bias-correction</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-intake-esm\"><span class=\"tag tag-access\">access:intake-esm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/cesm_gmst_ncar.ipynb
+++ b/notebooks/cesm_gmst_ncar.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "94776b8a",
+   "id": "3400ed79",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08731bf2",
+   "id": "0da6dfb7",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "039eac9b",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-intake-esm\"><span class=\"tag tag-access\">access:intake-esm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/cesm_oceanheat.ipynb
+++ b/notebooks/cesm_oceanheat.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2057fd30",
+   "id": "ac4237a7",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5a03510",
+   "id": "92eab43a",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8b96b2f7",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-intake-esm\"><span class=\"tag tag-access\">access:intake-esm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/cesm_osdf_stampede3.ipynb
+++ b/notebooks/cesm_osdf_stampede3.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "342a393e",
+   "id": "730823d1",
    "metadata": {},
    "source": [
     "---\n",
@@ -22,18 +22,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c33bcd0",
+   "id": "433a5af5",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-object-store\"><span class=\"tag tag-origin\">origin:ncar-object-store</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-stampede3\"><span class=\"tag tag-platform\">platform:stampede3</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-bias-correction\"><span class=\"tag tag-task\">task:bias-correction</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "014b40f5",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-stampede3\"><span class=\"tag tag-platform\">platform:stampede3</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-bias-correction\"><span class=\"tag tag-task\">task:bias-correction</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-intake-esm\"><span class=\"tag tag-access\">access:intake-esm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
    ]
   },
   {

--- a/notebooks/cmip6_bias_correction.ipynb
+++ b/notebooks/cmip6_bias_correction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a5763a3d",
+   "id": "e36f0999",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e6f94a2",
+   "id": "4e84b4bd",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-bias-correction\"><span class=\"tag tag-task\">task:bias-correction</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c2fe13ae",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-bias-correction\"><span class=\"tag tag-task\">task:bias-correction</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/cmip6_ecs.ipynb
+++ b/notebooks/cmip6_ecs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bf8ecd37",
+   "id": "32d4b58e",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "444f90fe",
+   "id": "9a5aedd8",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-ecs\"><span class=\"tag tag-task\">task:ecs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8bb378a6",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-ecs\"><span class=\"tag tag-task\">task:ecs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
    ]
   },
   {

--- a/notebooks/cmip6_gmst_zarr.ipynb
+++ b/notebooks/cmip6_gmst_zarr.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dd74b9ed",
+   "id": "329e4cc2",
    "metadata": {},
    "source": [
     "---\n",
@@ -22,18 +22,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf580147",
+   "id": "4e27075e",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-object-store\"><span class=\"tag tag-origin\">origin:ncar-object-store</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "53af8bbe",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/cmip6_precipitation.ipynb
+++ b/notebooks/cmip6_precipitation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9b6a5498",
+   "id": "802fdb9d",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ed2f702",
+   "id": "f5014cbf",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "52a43984",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/conus404.ipynb
+++ b/notebooks/conus404.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c9e0011c",
+   "id": "6a790ef4",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00bd4b0a",
+   "id": "e3596060",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-conus404\"><span class=\"tag tag-dataset\">dataset:conus404</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bf21a049",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-conus404\"><span class=\"tag tag-dataset\">dataset:conus404</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/dart-cam6.ipynb
+++ b/notebooks/dart-cam6.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "45ba39b1",
+   "id": "b92d772b",
    "metadata": {},
    "source": [
     "---\n",
@@ -21,18 +21,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efeae788",
+   "id": "6774fcf2",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-object-store\"><span class=\"tag tag-origin\">origin:ncar-object-store</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-dart\"><span class=\"tag tag-dataset\">dataset:dart</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bac08530",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-dart\"><span class=\"tag tag-dataset\">dataset:dart</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/eol_era5.ipynb
+++ b/notebooks/eol_era5.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8290f879",
+   "id": "c1be9f17",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38a7836e",
+   "id": "07c4a57e",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "761e7fab",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/era5_precip.ipynb
+++ b/notebooks/era5_precip.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bfdd1697",
+   "id": "935dc993",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a141071f",
+   "id": "0b8c2df7",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f31b6502",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/geocat_climatology.ipynb
+++ b/notebooks/geocat_climatology.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "05c8fed7",
+   "id": "142bc300",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93a9121e",
+   "id": "c02688ea",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-climatology\"><span class=\"tag tag-task\">task:climatology</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "15679589",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-climatology\"><span class=\"tag tag-task\">task:climatology</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/hadisst_elnino.ipynb
+++ b/notebooks/hadisst_elnino.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d3ed64cb",
+   "id": "664b3c32",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19e0f6c6",
+   "id": "9d2b9083",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-hadisst\"><span class=\"tag tag-dataset\">dataset:hadisst</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "02a11c46",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-hadisst\"><span class=\"tag tag-dataset\">dataset:hadisst</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/hrrr_aws.ipynb
+++ b/notebooks/hrrr_aws.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0388a2c2",
+   "id": "1afb4d8f",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a642bfc9",
+   "id": "effb5339",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-hrrr\"><span class=\"tag tag-dataset\">dataset:hrrr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2da62233",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-hrrr\"><span class=\"tag tag-dataset\">dataset:hrrr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/jetstream_cesm_oceanheat.ipynb
+++ b/notebooks/jetstream_cesm_oceanheat.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "93114c11",
+   "id": "2b9b67ab",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a391f42",
+   "id": "eb015604",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-jetstream2\"><span class=\"tag tag-platform\">platform:jetstream2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "68f8720c",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-jetstream2\"><span class=\"tag tag-platform\">platform:jetstream2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-intake-esm\"><span class=\"tag tag-access\">access:intake-esm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/jetstream_cmip6_gmst.ipynb
+++ b/notebooks/jetstream_cmip6_gmst.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3751974d",
+   "id": "62b734b1",
    "metadata": {},
    "source": [
     "---\n",
@@ -21,18 +21,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6466f04d",
+   "id": "d7b4cafb",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-jetstream2\"><span class=\"tag tag-platform\">platform:jetstream2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "17dddba7",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-jetstream2\"><span class=\"tag tag-platform\">platform:jetstream2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/jetstream_intro.ipynb
+++ b/notebooks/jetstream_intro.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4c7ccc8c",
+   "id": "38c8e6c9",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,18 +17,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eff83fb",
+   "id": "97f4f65d",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-platform-jetstream2\"><span class=\"tag tag-platform\">platform:jetstream2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-beginner\"><span class=\"tag tag-level\">level:beginner</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "34b4c2ce",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-platform-jetstream2\"><span class=\"tag tag-platform\">platform:jetstream2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-beginner\"><span class=\"tag tag-level\">level:beginner</span></a>"
    ]
   },
   {

--- a/notebooks/jja_heatindex.ipynb
+++ b/notebooks/jja_heatindex.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8e90eb41",
+   "id": "fe291547",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bb60290",
+   "id": "c23c3c8a",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dc0d29cb",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-era5\"><span class=\"tag tag-dataset\">dataset:era5</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/jra_3q.ipynb
+++ b/notebooks/jra_3q.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "95179032",
+   "id": "022a2c8b",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "291dd487",
+   "id": "5b748090",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-jra3q\"><span class=\"tag tag-dataset\">dataset:jra3q</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "64d09660",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-jra3q\"><span class=\"tag tag-dataset\">dataset:jra3q</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/ml_workflows/nino3.4_index.ipynb
+++ b/notebooks/ml_workflows/nino3.4_index.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c2c55d83",
+   "id": "b527bb6c",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb27a879",
+   "id": "1f5ce143",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-hadisst\"><span class=\"tag tag-dataset\">dataset:hadisst</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-ml\"><span class=\"tag tag-task\">task:ml</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "45582570",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-hadisst\"><span class=\"tag tag-dataset\">dataset:hadisst</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-ml\"><span class=\"tag tag-task\">task:ml</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/na_cordex.ipynb
+++ b/notebooks/na_cordex.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "262669be",
+   "id": "f4a30873",
    "metadata": {},
    "source": [
     "---\n",
@@ -21,18 +21,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d5d191b",
+   "id": "6b089504",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-object-store\"><span class=\"tag tag-origin\">origin:ncar-object-store</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-na-cordex\"><span class=\"tag tag-dataset\">dataset:na-cordex</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "24775125",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-na-cordex\"><span class=\"tag tag-dataset\">dataset:na-cordex</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/ndc_workflows/aws_benchmark.ipynb
+++ b/notebooks/ndc_workflows/aws_benchmark.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7a902c4b",
+   "id": "0c8da9cb",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac1e9e55",
+   "id": "ce7b300a",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "30bc050b",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cesm\"><span class=\"tag tag-dataset\">dataset:cesm</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/ndc_workflows/envistor_test_ap40.ipynb
+++ b/notebooks/ndc_workflows/envistor_test_ap40.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b3fa88ed",
+   "id": "6c2ebc58",
    "metadata": {},
    "source": [
     "---\n",
@@ -18,18 +18,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dadebc53",
+   "id": "9ed57604",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-platform-ospool\"><span class=\"tag tag-platform\">platform:ospool</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "afefe957",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-platform-ospool\"><span class=\"tag tag-platform\">platform:ospool</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
    ]
   },
   {

--- a/notebooks/ndc_workflows/ncar_benchmark.ipynb
+++ b/notebooks/ndc_workflows/ncar_benchmark.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "26d69bed",
+   "id": "f3992ee0",
    "metadata": {},
    "source": [
     "---\n",
@@ -21,18 +21,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "708b1261",
+   "id": "ea125353",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-dart\"><span class=\"tag tag-dataset\">dataset:dart</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a331b756",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-dart\"><span class=\"tag tag-dataset\">dataset:dart</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/ndc_workflows/ncar_benchmark_ap40.ipynb
+++ b/notebooks/ndc_workflows/ncar_benchmark_ap40.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7641c010",
+   "id": "21477ed0",
    "metadata": {},
    "source": [
     "---\n",
@@ -19,18 +19,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd5497e9",
+   "id": "13837af6",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-ospool\"><span class=\"tag tag-platform\">platform:ospool</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b5ac6935",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-ospool\"><span class=\"tag tag-platform\">platform:ospool</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
    ]
   },
   {

--- a/notebooks/ndc_workflows/ncar_benchmark_simple.ipynb
+++ b/notebooks/ndc_workflows/ncar_benchmark_simple.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ded2687c",
+   "id": "d9792e9a",
    "metadata": {},
    "source": [
     "---\n",
@@ -19,18 +19,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64cf1ac6",
+   "id": "98ea4ebe",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-beginner\"><span class=\"tag tag-level\">level:beginner</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "13501957",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-benchmark\"><span class=\"tag tag-task\">task:benchmark</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-beginner\"><span class=\"tag tag-level\">level:beginner</span></a>"
    ]
   },
   {

--- a/notebooks/ndc_workflows/pycogss_spectral_change.ipynb
+++ b/notebooks/ndc_workflows/pycogss_spectral_change.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e43ba65b",
+   "id": "1049d0eb",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4003710",
+   "id": "2d01e428",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-sentinel2\"><span class=\"tag tag-dataset\">dataset:sentinel2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3d209da4",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-sentinel2\"><span class=\"tag tag-dataset\">dataset:sentinel2</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/ndc_workflows/sonar_ai.ipynb
+++ b/notebooks/ndc_workflows/sonar_ai.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d45e2814",
+   "id": "c218484d",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2dfcd179",
+   "id": "1756effd",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-sonar\"><span class=\"tag tag-dataset\">dataset:sonar</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2439df55",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-sonar\"><span class=\"tag tag-dataset\">dataset:sonar</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/saag.ipynb
+++ b/notebooks/saag.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "905e34e4",
+   "id": "28dfb06f",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,18 +20,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8a8a228",
+   "id": "ae1b7e23",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-saag\"><span class=\"tag tag-dataset\">dataset:saag</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9ac344df",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-saag\"><span class=\"tag tag-dataset\">dataset:saag</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-intermediate\"><span class=\"tag tag-level\">level:intermediate</span></a>"
    ]
   },
   {

--- a/notebooks/simple_aws_example.ipynb
+++ b/notebooks/simple_aws_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fd79bbd2",
+   "id": "47431cce",
    "metadata": {},
    "source": [
     "---\n",
@@ -19,18 +19,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "021d8eda",
+   "id": "3e2bba7c",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-beginner\"><span class=\"tag tag-level\">level:beginner</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c9ea72e0",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-aws\"><span class=\"tag tag-origin\">origin:aws</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-laptop\"><span class=\"tag tag-platform\">platform:laptop</span></a> <a class=\"tag-link\" href=\"tag-index#tag-dataset-cmip6\"><span class=\"tag tag-dataset\">dataset:cmip6</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-zarr\"><span class=\"tag tag-access\">access:zarr</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-beginner\"><span class=\"tag tag-level\">level:beginner</span></a>"
    ]
   },
   {

--- a/notebooks/uxarray_test.ipynb
+++ b/notebooks/uxarray_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7b6890ca",
+   "id": "bca74d2a",
    "metadata": {},
    "source": [
     "---\n",
@@ -19,18 +19,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90a65fdb",
+   "id": "934203ce",
    "metadata": {},
    "source": [
     "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-posix\"><span class=\"tag tag-origin\">origin:ncar-posix</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a44b17bc",
-   "metadata": {},
-   "source": [
-    "<a class=\"tag-link\" href=\"tag-index#tag-origin-ncar-data-origin\"><span class=\"tag tag-origin\">origin:ncar-data-origin</span></a> <a class=\"tag-link\" href=\"tag-index#tag-platform-casper\"><span class=\"tag tag-platform\">platform:casper</span></a> <a class=\"tag-link\" href=\"tag-index#tag-task-visualization\"><span class=\"tag tag-task\">task:visualization</span></a> <a class=\"tag-link\" href=\"tag-index#tag-access-pelicanfs\"><span class=\"tag tag-access\">access:pelicanfs</span></a> <a class=\"tag-link\" href=\"tag-index#tag-level-advanced\"><span class=\"tag tag-level\">level:advanced</span></a>"
    ]
   },
   {

--- a/scripts/maintenance/tag_notebooks.py
+++ b/scripts/maintenance/tag_notebooks.py
@@ -300,10 +300,11 @@ def find_existing_h1(nb: dict) -> str | None:
 
 
 TAG_CELL_MARKERS = (
-    "**Tags:**",            # original code-span format
-    "[origin:",             # bracketed-attr format (MyST didn't parse)
+    "**Tags:**",                  # original code-span format
+    "[origin:",                   # bracketed-attr format (MyST didn't parse)
     "[platform:",
-    '<span class="tag',     # current HTML-span format
+    '<span class="tag',           # earlier HTML-span format (no anchor)
+    '<a class="tag-link"',        # current anchor-wrapped HTML-span format
 )
 
 


### PR DESCRIPTION
The is_tag_cell() detector only matched cells starting with <span class="tag, which missed both the previous bracketed-attr format and the current <a class="tag-link"> anchor-wrapped format. Result: each script run inserted a fresh tag cell without removing the prior one, so notebooks ended up with two tag rows showing stale + current values.

Add the anchor-wrapped marker to TAG_CELL_MARKERS and re-run the script. Verified: every notebook now has exactly one tag cell.