### PR TITLE
Add pip requirements.txt mirroring environment.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ infrastructure, see
 
 ## Quick Start
 
+**conda** (recommended — handles the compiled geoscience libraries natively):
+
 ```bash
 git clone https://github.com/NCAR/osdf-examples.git
 cd osdf-examples
@@ -30,8 +32,20 @@ conda activate osdf
 jupyter lab
 ```
 
-`environment.yml` lists direct dependencies and solves on any OS
-(Linux/macOS/Windows).
+**pip / virtualenv** (e.g. on systems without conda):
+
+```bash
+git clone https://github.com/NCAR/osdf-examples.git
+cd osdf-examples
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+jupyter lab
+```
+
+Both `environment.yml` and `requirements.txt` list the same direct
+dependencies and work on Linux, macOS, and Windows. A few packages
+(cartopy, cf-units, geocat-comp, netCDF4) link against system libraries;
+conda installs those automatically, while pip relies on prebuilt wheels.
 
 New here? Start with [`notebooks/simple_aws_example.ipynb`](notebooks/simple_aws_example.ipynb)
 (runs on a laptop, no credentials required).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,81 @@
+# pip requirements for running the osdf-examples notebooks.
+#
+# Direct dependencies only (PyPI names), no version pins, so it installs on
+# Linux, macOS, and Windows. This mirrors environment.yml for users who
+# prefer pip / virtualenv over conda:
+#
+#   python -m venv .venv && source .venv/bin/activate
+#   pip install -r requirements.txt
+#
+# Note: a few packages (cartopy, cf-units, geocat-comp, netCDF4) link against
+# system libraries (GEOS, PROJ, UDUNITS2, HDF5). pip wheels bundle these on
+# most platforms; if a build fails, install that library via your OS package
+# manager (or use environment.yml with conda, which handles them natively).
+
+# Core scientific Python
+numpy
+pandas
+scipy
+xarray
+matplotlib
+seaborn
+
+# Geoscience / climate
+cartopy
+cf-units
+cftime
+nc-time-axis
+geocat-comp
+uxarray
+xarray-regrid
+xhistogram
+geopandas
+shapely
+pyproj
+rioxarray
+
+# OSDF data access + catalogs
+pelicanfs
+intake
+intake-esm
+kerchunk
+zarr
+fsspec
+aiohttp
+requests
+netCDF4
+h5netcdf
+s3fs
+# Parquet engines for kerchunk lazy references. pyarrow is the preferred
+# engine; fastparquet mis-decodes null `raw` cells in lazy-parquet references
+# as NaN (see the mesaclip notebook). Keep both; select pyarrow explicitly
+# when opening such references.
+pyarrow
+fastparquet
+
+# Parallel compute
+dask
+distributed
+dask-jobqueue   # NCAR PBSCluster on Casper / Derecho
+dask-gateway    # cloud / JupyterHub gateway setups
+
+# ML
+scikit-learn
+
+# Interactive maps / plotting extras
+folium
+branca
+
+# Misc
+tqdm
+psutil
+nest-asyncio
+
+# Jupyter
+jupyterlab
+ipykernel
+ipywidgets
+
+# Colormaps + heat-index helper (pip-only)
+cmap
+heatindex


### PR DESCRIPTION
The PelicanFS collaborator (and other pip/virtualenv users) need a pip-installable dependency file. Adds a clean, cross-platform requirements.txt with the same direct dependencies as environment.yml (PyPI names, no version pins). Verified all 252 transitive packages resolve from PyPI via `pip install --dry-run --ignore-installed`.

README Quick Start now documents both the conda and pip install paths.

This is a clean direct-dependency list — NOT the old `pip freeze` dump that previously lived here (removed when environment.yml was added).